### PR TITLE
fix: cover basic vue-casl usage in doc

### DIFF
--- a/docs/client-side.md
+++ b/docs/client-side.md
@@ -55,12 +55,12 @@ The best way to keep the rules, is in our `vuex`-store. So first, we add a custo
 
 ```js
 // src/store/vuex.plugin.casl.js
-import { Ability } from '@casl/ability';
+import { Ability, createAliasResolver, detectSubjectType as defaultDetector } from '@casl/ability';
 import { BaseModel } from '@/src/store/feathers/client.js';
 
 const detectSubjectType = (subject) => {
   if (typeof subject === 'string') return subject;
-  if (!(subject instanceof BaseModel)) return undefined;
+  if (!(subject instanceof BaseModel)) return defaultDetector(subject);
   return subject.constructor.servicePath;
 }
 


### PR DESCRIPTION
This small doc fix allow to use this.$can with locally created abilities (include abilities with conditions). It also correctly work with instances, because use all variants of detection: custom (feathers-vuex way with servicePath) and default ([how it should be](https://casl.js.org/v5/en/guide/subject-type-detection))