### PR TITLE
feat: allow passing async ability function in channel options

### DIFF
--- a/lib/channels/channels.utils.ts
+++ b/lib/channels/channels.utils.ts
@@ -48,16 +48,16 @@ const getAppOptions = (app: Application): ChannelOptions | Record<string, never>
     : {};
 };
 
-export const getAbility = (
+export const getAbility = async (
   app: Application, 
   data: Record<string, unknown>,
   connection: RealTimeConnection,
   context: HookContext,
   options: Partial<ChannelOptions>
-): undefined | AnyAbility => {
+): Promise<undefined | AnyAbility> => {
   if (options.ability) {
     return (typeof options.ability === "function") ?
-      options.ability(app, connection, data, context) :
+      await options.ability(app, connection, data, context) :
       options.ability;
   } else {
     return connection.ability;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -57,7 +57,7 @@ export type EventName = "created" | "updated" | "patched" | "removed";
 
 
 export interface ChannelOptions extends AuthorizeChannelCommonsOptions {
-  ability: AnyAbility | ((app: Application, connection: RealTimeConnection, data: unknown, context: HookContext) => AnyAbility)
+  ability: AnyAbility | ((app: Application, connection: RealTimeConnection, data: unknown, context: HookContext) => Promise<AnyAbility> | AnyAbility)
   /** Easy way to disable filtering, default: `false` */
   activated: boolean
   /** Channel that's used when there occures an error, default: `['authenticated']` */


### PR DESCRIPTION
I'm trying to update the ability for channels by passing a function to `channels.makeOptions`:

```ts
const caslOptions = channels.makeOptions(app, {
  ability: (a, conn) => defineAbilitiesFor(conn.user, a),
});
```

Since `defineAbilitiesFor` is `async` (for querying data needed to create the ability, similar to https://github.com/fratzinger/feathers-casl/issues/31), I added:

- `await` before calling `options.ability`
- call to `getAbility` when `options.restrictFields === true`

If there is a better way to update stale abilities for channels, any pointers in the right direction would be much appreciated.