### PR TITLE
refactor!: export default as 'feathersCasl'

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,12 +60,12 @@ pnpm i feathers-casl @casl/ability
 
 ```ts
 // app.ts
-import casl from "feathers-casl";
+import { feathersCasl } from "feathers-casl";
 
-app.configure(casl());
+app.configure(feathersCasl());
 ```
 
-The `casl()` function can be configured, to provide app wide options to `feathers-casl`
+The `feathersCasl()` function can be configured, to provide app wide options to `feathers-casl`
 
 ### Define static rules
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,6 @@ export * from "./hooks";
 export * from "./channels";
 export * from "./utils";
 
-import initialize from "./initialize";
-
-export default initialize;
+export { initialize as feathersCasl } from "./initialize";
 
 export * from "./types";
-
-if (typeof module !== "undefined") {
-  module.exports = Object.assign(initialize, module.exports);
-}

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -10,7 +10,7 @@ import type {
   InitOptions,
 } from "./types";
 
-export default (
+export const initialize = (
   options?: PartialDeep<InitOptions>
 ): ((app: Application) => void) => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/test/app/options.test.ts
+++ b/test/app/options.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import type { Application, HookContext } from "@feathersjs/feathers";
 import { feathers } from "@feathersjs/feathers";
 import { MemoryService } from "@feathersjs/memory";
-import casl, { authorize } from "../../src";
+import { feathersCasl, authorize } from "../../src";
 import type { RealTimeConnection } from "@feathersjs/transport-commons";
 import type { InitOptions } from "../../src";
 import { defineAbility } from "@casl/ability";
@@ -59,7 +59,7 @@ describe("app-options / service-options", function () {
       let calledChannelAbility = false;
       let calledChannelModelName = false;
       app.configure(
-        casl({
+        feathersCasl({
           authorizeHook: {
             actionOnForbidden: () => {
               calledActionOnForbidden = true;
@@ -155,7 +155,7 @@ describe("app-options / service-options", function () {
       });
 
       app.configure(
-        casl({
+        feathersCasl({
           authorizeHook: {
             actionOnForbidden: () => {
               appCalled.calledActionOnForbidden = true;

--- a/test/channels/.mockServer/index.ts
+++ b/test/channels/.mockServer/index.ts
@@ -11,7 +11,7 @@ import type { MemoryService } from "@feathersjs/memory";
 process.env["NODE_CONFIG_DIR"] = path.join(__dirname, "config/");
 import configuration from "@feathersjs/configuration";
 
-import casl from "../../../src";
+import { feathersCasl } from "../../../src";
 
 interface MockServerOptions {
   channels: (app: Application) => void;
@@ -56,7 +56,7 @@ export const mockServer = (options: MockServerOptions) => {
   const comments = app.service("comments");
   const users = app.service("users");
 
-  app.configure(casl());
+  app.configure(feathersCasl());
   return {
     app: app,
     articles,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert";
-import index, {
+import {
+  feathersCasl,
   authorize,
   checkBasicPermission,
   getChannelsWithReadAbility,
+  checkBasicPermissionUtil,
+  checkCan,
+  makeChannelOptions,
 } from "../src";
 import { feathers } from "@feathersjs/feathers";
 
@@ -18,7 +22,7 @@ describe("index", function () {
   it("default is initialize", function () {
     const app = feathers();
     assert.ok(!app.get("casl"), "casl is not set");
-    index()(app);
+    feathersCasl()(app);
     assert.ok(app.get("casl"), "casl is set");
   });
 
@@ -26,5 +30,8 @@ describe("index", function () {
     assert.ok(authorize, "authorize is ok");
     assert.ok(checkBasicPermission, "checkBasicPermission is ok");
     assert.ok(getChannelsWithReadAbility, "getChannelsWithReadAbility is ok");
+    assert.ok(checkCan);
+    assert.ok(checkBasicPermissionUtil);
+    assert.ok(makeChannelOptions);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE

Because of quirks between CommonJS and ESM I have to make a change to the default import. This is the change:

```ts
// old code
import casl from "feathers-casl"
```

Becomes this:

```ts
// new code
import { feathersCasl } from "feathers-casl";
```
