### PR TITLE
Fix find with pagination

### DIFF
--- a/src/hooks/authorize/authorize.hook.after.ts
+++ b/src/hooks/authorize/authorize.hook.after.ts
@@ -38,7 +38,7 @@ export const authorizeAfter = async <H extends HookContext = HookContext>(
   }
 
   // eslint-disable-next-line prefer-const
-  let { isArray, items } = getItemsIsArray(context, { from: "result" });
+  let { isArray, items } = getItemsIsArray(context, { from: "automatic" });
   if (!items.length) {
     return context;
   }

--- a/test/hooks/authorize/authorize.general.test.ts
+++ b/test/hooks/authorize/authorize.general.test.ts
@@ -896,5 +896,53 @@ describe("authorize.general.test.ts", function () {
       });
       await Promise.all(promises);
     });
+
+    it("after - passes multi with 'pagination' with 'find' rule", async function () {
+      const expectedResult = {
+        "total": 1,
+        "limit": 10,
+        "skip": 0,
+        "data": [{ id: 1, userId: 1, test: true }]
+      };
+      const makeContext = (method, type) => {
+        return {
+          service: {},
+          path: "tests",
+          method,
+          type,
+          result: _cloneDeep(expectedResult),
+          id: null,
+          params: {
+            ability: defineAbility(
+              (can) => {
+                can(["find", "create", "patch", "remove"], "all");
+              },
+              { resolveAction }
+            ),
+            query: {},
+          },
+        } as unknown as HookContext;
+      };
+  
+      const types = ["after"];
+      const methods = ["find"];
+      const promises: Promise<any>[] = [];
+      types.forEach((type) => {
+        methods.forEach((method) => {
+          const context = makeContext(method, type);
+          const promise = authorize({ availableFields: undefined })(
+            context
+          ).then(({ result }) => {
+            assert.deepStrictEqual(
+              result,
+              expectedResult,
+              `returns complete object for '${type}:${method}'`
+            );
+          });
+          promises.push(promise);
+        });
+      });
+      await Promise.all(promises);
+    });
   });
 });


### PR DESCRIPTION
To fix data filtering when a restriction on allowed fields is set in the `authorizeAfter` function, the parameter for calling the `getItemsIsArray` function was changed from `{ from: "result"}` to `{ from: "automatic" }`. Which led to the correct setting of the `isArray=true` and `getOrFind=find` variables and the correct data filtering in the `pickFieldsForItem` function.

The **after - passes multi with 'pagination' with 'find' rule** test has been added to the file '\test\hooks\authorize\authorize.general.test.ts'.

Fix #95 